### PR TITLE
add stale data detection instructions

### DIFF
--- a/devices/enelogic/faq/generic/languages/en-US.md
+++ b/devices/enelogic/faq/generic/languages/en-US.md
@@ -12,6 +12,10 @@ Frequently asked information about the Enelogic online data souce.
 - Daily readings up to 40 days ago
 - Monthly readings up to 13 months ago
 
+## 2. How can I check if the data collection is working properly?
+
+Look in the NeedForHeat app under the 'Smart meter via Enelogic' data source. If this is within the last 2 days (48 hours), everything is functioning correctly. You'll notice this immediately if you've just added Enelogic to the app. Once you've linked your smart meter to your Enelogic account, it usually takes 1.5 days for Enelogic to receive data for the first time. After that, the research server retrieves new data from your Enelogic account once a day.
+
 ## What if I have other questions or comments?
 
 Then, please send an email to the helpdesk of the NeedForHeat research at [needforheatresearch@windesheim.nl](needforheatresearch@windesheim.nl).

--- a/devices/enelogic/faq/generic/languages/nl-NL.md
+++ b/devices/enelogic/faq/generic/languages/nl-NL.md
@@ -12,5 +12,8 @@ Veelgevraagde informatie over de woonkamermodule.
 - dagstanden tot 40 dagen geleden
 - maandstanden tot 13 maanden geleden
 
+# 2. Hoe kan ik zien dat de dataverzameling goed loopt?
+Kijk in de NeedForHeat-app bij 'Bronnen' onder de sectie 'Slimme meter via Enelogic'. Als dit minder dan 2 dagen (48 uur) geleden is, gaat alles goed. Als je Enelogic net hebt toegevoegd, zie je dat meteen. Wanneer je je slimme meter aan Enelogic hebt gekoppeld, duurt het meestal 1,5 dag voordat Enelogic voor het eerst gegevens ontvangt. Daarna haalt de onderzoeksserver eenmaal per dag nieuwe gegevens op van je Enelogic-account.   
+
 ## Wat als ik andere vragen of opmerkingen heb?
 Stuur dan een e-mail naar de helpdesk van het NeedForHeat-onderzoek via [needforheatonderzoek@windesheim.nl](needforheatonderzoek@windesheim.nl).

--- a/devices/enelogic/faq/reducedheatcarb2023/languages/en-US.md
+++ b/devices/enelogic/faq/reducedheatcarb2023/languages/en-US.md
@@ -12,6 +12,10 @@ Frequently asked information about the Enelogic online data souce.
 - Daily readings up to 40 days ago
 - Monthly readings up to 13 months ago
 
+## 2. How can I check if the data collection is working properly?
+
+Look in the NeedForHeat app under the 'Smart meter via Enelogic' data source. If this is within the last 2 days (48 hours), everything is functioning correctly. You'll notice this immediately if you've just added Enelogic to the app. Once you've linked your smart meter to your Enelogic account, it usually takes 1.5 days for Enelogic to receive data for the first time. After that, the research server retrieves new data from your Enelogic account once a day.
+
 ## What if I have other questions or comments?
 
 Then, please send an email to the helpdesk of the NeedForHeat research at [needforheatresearch@windesheim.nl](needforheatresearch@windesheim.nl).

--- a/devices/enelogic/faq/reducedheatcarb2023/languages/nl-NL.md
+++ b/devices/enelogic/faq/reducedheatcarb2023/languages/nl-NL.md
@@ -12,5 +12,8 @@ Veelgevraagde informatie over de woonkamermodule.
 - dagstanden tot 40 dagen geleden
 - maandstanden tot 13 maanden geleden
 
+# 2. Hoe kan ik zien dat de dataverzameling goed loopt?
+Kijk in de NeedForHeat-app bij 'Bronnen' onder de sectie 'Slimme meter via Enelogic'. Als dit minder dan 2 dagen (48 uur) geleden is, gaat alles goed. Als je Enelogic net hebt toegevoegd, zie je dat meteen. Wanneer je je slimme meter aan Enelogic hebt gekoppeld, duurt het meestal 1,5 dag voordat Enelogic voor het eerst gegevens ontvangt. Daarna haalt de onderzoeksserver eenmaal per dag nieuwe gegevens op van je Enelogic-account.   
+
 ## Wat als ik andere vragen of opmerkingen heb?
 Stuur dan een e-mail naar de helpdesk van het NeedForHeat-onderzoek via [needforheatonderzoek@windesheim.nl](needforheatonderzoek@windesheim.nl).


### PR DESCRIPTION
I assumed that |Enelogic data collection is running once per day, at a suitable time.

Considering that P3/P4 data is harvested from smart meters by Enelogic somewhere after 0:00, it may be wise to target somewhere between 3 and 6 am?